### PR TITLE
Fix non strict mode error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function asCallback(promise, cb, options) {
   if (typeof cb !== 'function') return promise
 


### PR DESCRIPTION
In Node v4.4.5, I get this error:

```
ascallback/index.js:4
  let p = promise.then(function (ret) {
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Using strict for this module helps.  BTW, I am using asCallback because socket.io-as-promised requires it. Thanks!
